### PR TITLE
chore(deps): use alpine 3.20.1, use latest custom-runner (v0.9.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/kube-logging/custom-runner:v0.8.0 as custom-runner
 
-FROM alpine:3.18
+FROM alpine:3.20.1@sha256:b89d9c93e9ed3597455c90a0b88a8bbb5cb7188438f70953fede212a0c4394e0
 
 RUN apk add socat
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/kube-logging/custom-runner:v0.8.0 as custom-runner
+FROM ghcr.io/kube-logging/custom-runner:v0.9.0 as custom-runner
 
 FROM alpine:3.20.1@sha256:b89d9c93e9ed3597455c90a0b88a8bbb5cb7188438f70953fede212a0c4394e0
 


### PR DESCRIPTION
Signed-off-by: Szilard Parrag <szilard.parrag@axoflow.com>

- [x] rerun CI once the new custom-runner image has been released